### PR TITLE
arm64: dts: violet: Drop Android Verified Boot flag

### DIFF
--- a/arch/arm64/boot/dts/xiaomi/violet/violet-sm6150.dtsi
+++ b/arch/arm64/boot/dts/xiaomi/violet/violet-sm6150.dtsi
@@ -27,7 +27,7 @@
         };
         fstab {
             vendor {
-                fsmgr_flags = "wait,avb";
+                fsmgr_flags = "wait";
             };
         };
     };


### PR DESCRIPTION
AVB checks if the code is coming from a trusted source/OEMs. Since
we are already running AOSP and MIUI will never support custom
kernels based on R tags, no need to keep AVB.

Source: https://source.android.com/security/verifiedboot

Change-Id: Ifd3e8b9b90944eb4ab2736cd6398d7b429542391
Signed-off-by: Panchajanya1999 <panchajanya@azure-dev.live>